### PR TITLE
Changed the properties valueByteLength and valueStartPosition to be library private

### DIFF
--- a/lib/asn1bitstring.dart
+++ b/lib/asn1bitstring.dart
@@ -22,7 +22,7 @@ class ASN1BitString extends ASN1Object {
   Uint8List _encode() {
     var valBytes = [unusedbits];
     valBytes.addAll(stringValue);
-    valueByteLength  = valBytes.length;
+    _valueByteLength  = valBytes.length;
     _encodeHeader();
     _setValueBytes(valBytes);
     return _encodedBytes;

--- a/lib/asn1bitstring.dart
+++ b/lib/asn1bitstring.dart
@@ -13,9 +13,7 @@ class ASN1BitString extends ASN1Object {
   ASN1BitString(this.stringValue, {this.unusedbits: 0, int tag: BIT_STRING_TYPE}):super(tag:tag);
 
   /// Create an [ASN1OctetString] from an encoded list of bytes
-  ASN1BitString.fromBytes(Uint8List bytes) {
-    _encodedBytes = bytes;
-    _initFromBytes();
+  ASN1BitString.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
     unusedbits = bytes[0];
     stringValue = valueBytes().sublist(1);
   }

--- a/lib/asn1boolean.dart
+++ b/lib/asn1boolean.dart
@@ -14,12 +14,12 @@ class ASN1Boolean extends ASN1Object {
 
   // ASN1Boolean(this._boolValue,{tag: BOOLEAN_TYPE}):super(tag:BOOLEAN_TYPE) {
   ASN1Boolean(this._boolValue,{tag: BOOLEAN_TYPE}):super(tag:tag) {
-    valueByteLength = 1;
+    _valueByteLength = 1;
   }
 
 
   ASN1Boolean.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
-    var b = bytes[valueStartPosition];
+    var b = bytes[_valueStartPosition];
     _boolValue = (b == BOOLEAN_TRUE_VALUE);
   }
 

--- a/lib/asn1boolean.dart
+++ b/lib/asn1boolean.dart
@@ -18,9 +18,7 @@ class ASN1Boolean extends ASN1Object {
   }
 
 
-  ASN1Boolean.fromBytes(Uint8List bytes) {
-    _encodedBytes = bytes;
-    _initFromBytes();
+  ASN1Boolean.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
     var b = bytes[valueStartPosition];
     _boolValue = (b == BOOLEAN_TRUE_VALUE);
   }

--- a/lib/asn1integer.dart
+++ b/lib/asn1integer.dart
@@ -7,9 +7,7 @@ class ASN1Integer extends ASN1Object {
 
   ASN1Integer(this.intValue,{tag:INTEGER_TYPE}):super(tag:tag);
 
-  ASN1Integer.fromBytes(Uint8List bytes) {
-    _encodedBytes = bytes;
-    _initFromBytes();
+  ASN1Integer.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
     intValue = decodeInteger(this.valueBytes());
   }
 

--- a/lib/asn1integer.dart
+++ b/lib/asn1integer.dart
@@ -25,7 +25,7 @@ class ASN1Integer extends ASN1Object {
   @override
   Uint8List _encode() {
     var t = encodeIntValue(this.intValue);
-    valueByteLength  = t.length;
+    _valueByteLength  = t.length;
     super._encodeHeader();
     _setValueBytes(t);
     return _encodedBytes;

--- a/lib/asn1null.dart
+++ b/lib/asn1null.dart
@@ -11,9 +11,6 @@ class ASN1Null extends ASN1Object {
   ASN1Null():super(tag:NULL_TYPE);
   
   
-  ASN1Null.fromBytes(Uint8List bytes) {
-        _encodedBytes = bytes;
-        _initFromBytes();
-    }
+  ASN1Null.fromBytes(Uint8List bytes) : super.fromBytes(bytes);
 
 }

--- a/lib/asn1object.dart
+++ b/lib/asn1object.dart
@@ -54,9 +54,9 @@ class ASN1Object {
    *
    */
   ASN1Object.preEncoded(int tag, Uint8List valBytes) : _tag = tag {
-    valueByteLength = valBytes.length;
+    _valueByteLength = valBytes.length;
     _encodeHeader();
-    _encodedBytes.setRange(valueStartPosition, valBytes.length, valBytes);
+    _encodedBytes.setRange(_valueStartPosition, valBytes.length, valBytes);
   }
 
   /**
@@ -79,8 +79,8 @@ class ASN1Object {
    */
   void _initFromBytes() {
     ASN1Length l = ASN1Length.decodeLength(_encodedBytes);
-    valueByteLength = l.length;
-    valueStartPosition = l.valueStartPosition;
+    _valueByteLength = l.length;
+    _valueStartPosition = l.valueStartPosition;
   }
 
   /**
@@ -91,7 +91,7 @@ class ASN1Object {
    * next object starts in the stream.
    *
    */
-  int get totalEncodedByteLength => valueStartPosition + valueByteLength;
+  int get totalEncodedByteLength => _valueStartPosition + _valueByteLength;
 
 
 
@@ -99,14 +99,14 @@ class ASN1Object {
    * Length of the encoded value bytes. This does not include the length of
    * the tag or length fields. See [totalEncodedByteLength].
    */
-  int valueByteLength;
+  int _valueByteLength;
 
   /**
    * The index where the value bytes start. This is the position after the tag + length bytes.
    * defaults to 2 - but encoding may change this value if more bytes are needed
    * to encode the length field.
    */
-  int valueStartPosition = 2;
+  int _valueStartPosition = 2;
 
   /**
    *
@@ -120,11 +120,11 @@ class ASN1Object {
    */
   Uint8List _encodeHeader() {
     if( _encodedBytes == null ) {
-      Uint8List lenEnc= ASN1Length.encodeLength(valueByteLength);
-      _encodedBytes = new Uint8List( 1 + lenEnc.length + valueByteLength);
+      Uint8List lenEnc= ASN1Length.encodeLength(_valueByteLength);
+      _encodedBytes = new Uint8List( 1 + lenEnc.length + _valueByteLength);
       _encodedBytes[0] = tag;
       _encodedBytes.setRange(1, 1 + lenEnc.length , lenEnc, 0);
-      valueStartPosition = 1 + lenEnc.length;
+      _valueStartPosition = 1 + lenEnc.length;
     }
     return _encodedBytes;
   }
@@ -140,22 +140,22 @@ class ASN1Object {
    */
   Uint8List valueBytes() {
     return new Uint8List.view( _encodedBytes.buffer,
-        valueStartPosition + _encodedBytes.offsetInBytes, valueByteLength);
+        _valueStartPosition + _encodedBytes.offsetInBytes, _valueByteLength);
   }
 
 
 
   // Subclasses can call this to set the value bytes
   void _setValueBytes(List<int> valBytes) {
-    this.encodedBytes.setRange(valueStartPosition,
-        valueStartPosition + valBytes.length, valBytes);
+    this.encodedBytes.setRange(_valueStartPosition,
+        _valueStartPosition + valBytes.length, valBytes);
   }
 
   toHexString() => ASN1Util.listToString(encodedBytes);
 
   @override
   String toString() =>
-   "ASN1Object(tag=${tag.toRadixString(16)} valueByteLength=${valueByteLength}) startpos=$valueStartPosition bytes=${toHexString()}";
+   "ASN1Object(tag=${tag.toRadixString(16)} valueByteLength=${_valueByteLength}) startpos=$_valueStartPosition bytes=${toHexString()}";
 }
 
 

--- a/lib/asn1object.dart
+++ b/lib/asn1object.dart
@@ -16,7 +16,7 @@ part of asn1lib;
  */
 class ASN1Object {
   /** The BER tag representing this object */
-  int _tag;
+  final int _tag;
   int get tag => _tag;
 
 
@@ -44,9 +44,7 @@ class ASN1Object {
 
 
   // Create an ASN1Object. Optionally set the tag
-  ASN1Object({int tag:0}) {
-    this._tag = tag;
-  }
+  ASN1Object({int tag:0}) : _tag = tag;
 
   /**
    * Create an object that encapsulates a set of value bytes that are already
@@ -55,8 +53,7 @@ class ASN1Object {
    * The supplied valBytes is the encoded value of the choice element
    *
    */
-  ASN1Object.preEncoded(int tag,Uint8List valBytes) {
-    _tag = tag;
+  ASN1Object.preEncoded(int tag, Uint8List valBytes) : _tag = tag {
     valueByteLength = valBytes.length;
     _encodeHeader();
     _encodedBytes.setRange(valueStartPosition, valBytes.length, valBytes);
@@ -71,8 +68,8 @@ class ASN1Object {
    * byte stream we dont always know how long an object is
    * until we complete parsing it).
    */
-
-  ASN1Object.fromBytes(this._encodedBytes) {
+  ASN1Object.fromBytes(bytes) : _tag = bytes[0] {
+    _encodedBytes = bytes;
     _initFromBytes();
   }
 
@@ -80,8 +77,7 @@ class ASN1Object {
    * Perform initial decoding common to all ASN1 Objects
    * Determines the length and where the value bytes start
    */
-  _initFromBytes() {
-    _tag = _encodedBytes[0];
+  void _initFromBytes() {
     ASN1Length l = ASN1Length.decodeLength(_encodedBytes);
     valueByteLength = l.length;
     valueStartPosition = l.valueStartPosition;

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -7,10 +7,7 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
   
   ASN1ObjectIdentifier(this.oi,{tag:OBJECT_IDENTIFIER}):super(tag:tag);
 
-  ASN1ObjectIdentifier.fromBytes(Uint8List bytes) {
-      _encodedBytes = bytes;
-      _initFromBytes();
-  }
+  ASN1ObjectIdentifier.fromBytes(Uint8List bytes) : super.fromBytes(bytes);
 
   @override
   Uint8List _encode() {

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -11,7 +11,7 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
 
   @override
   Uint8List _encode() {
-      valueByteLength  = oi.length;
+      _valueByteLength  = oi.length;
       super._encodeHeader();
       _setValueBytes(oi);
       return _encodedBytes;

--- a/lib/asn1octetstring.dart
+++ b/lib/asn1octetstring.dart
@@ -32,7 +32,7 @@ class ASN1OctetString extends ASN1Object {
 
   @override
   Uint8List _encode() {
-    valueByteLength  = octets.length;
+    _valueByteLength  = octets.length;
     _encodeHeader();
     _setValueBytes(octets);
     //this.encodedBytes.setRange(valueStartPosition,

--- a/lib/asn1octetstring.dart
+++ b/lib/asn1octetstring.dart
@@ -22,9 +22,7 @@ class ASN1OctetString extends ASN1Object {
   }
 
   /// Create an [ASN1OctetString] from an encoded list of bytes
-  ASN1OctetString.fromBytes(Uint8List bytes) {
-    _encodedBytes = bytes;
-    _initFromBytes();
+  ASN1OctetString.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
     octets = valueBytes();
   }
 

--- a/lib/asn1sequence.dart
+++ b/lib/asn1sequence.dart
@@ -14,14 +14,10 @@ class ASN1Sequence extends ASN1Object {
    * Note that bytes array b could be longer than the actual encoded sequence - in which case
    * we ignore any remaining bytes
    */
-  ASN1Sequence.fromBytes(Uint8List b) {
-    this._tag = b[0];
-    // todo; Check if b[0] is a valid sequence type???
+  ASN1Sequence.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
+    // todo; Check if tag is a valid sequence type???
     if( (tag & 0x30) == 0 )
       throw new ASN1Exception("The tag ${tag} does not look like a sequence type");
-
-    _encodedBytes = b;
-    super._initFromBytes();
     //print("ASN1Sequence valbytes=${hex(valueBytes())}");
     _decodeSeq();
   }

--- a/lib/asn1sequence.dart
+++ b/lib/asn1sequence.dart
@@ -34,9 +34,9 @@ class ASN1Sequence extends ASN1Object {
 
 
   Uint8List _encode() {
-   valueByteLength = _childLength();
+   _valueByteLength = _childLength();
    super._encodeHeader();
-   var i = valueStartPosition;
+   var i = _valueStartPosition;
    // encode each element
    elements.forEach( (obj) {
      var  b = obj.encodedBytes;

--- a/lib/asn1set.dart
+++ b/lib/asn1set.dart
@@ -15,15 +15,10 @@ class ASN1Set extends ASN1Object {
    * Note that bytes could be longer than the actual sequence - in which case
    * we would ignore any remaining bytes
    */
-  ASN1Set.fromBytes(Uint8List b) {
-    //this.tag = SEQUENCE_TYPE;
-    this._tag = b[0];
-    // todo; Check if b[0] is a valid sequence type???
+  ASN1Set.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
+    // todo; Check if tag is a valid sequence type???
     if( (tag & 0x30) == 0 )
       throw new ASN1Exception("The tag ${tag} does not look like a set type");
-
-    _encodedBytes = b;
-    super._initFromBytes();
     _decodeSet();
   }
 

--- a/lib/asn1set.dart
+++ b/lib/asn1set.dart
@@ -31,11 +31,11 @@ class ASN1Set extends ASN1Object {
 
   @override
   Uint8List _encode() {
-   valueByteLength = _childLength();
+   _valueByteLength = _childLength();
    //super._encode();
 
    super._encodeHeader();
-   var i = valueStartPosition;
+   var i = _valueStartPosition;
    elements.forEach( (obj) {
      var  b = obj.encodedBytes;
      encodedBytes.setRange(i, i + b.length, b);


### PR DESCRIPTION
They seem to be not required in the interface (as there is totalEncodedByteLength) and if (accidentally) changed they can cause a lot of problems.

This does however change the interface. I wonder, however, how users can need to access the properties in a legal manner.

If they are really required in some way, I would suggest making getters for them so that they cannot be changed.