### PR TITLE
Remove obsolete crypto dependency in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ var s2 = p.nextObject();
 
 # Changes 
 
+Remove obsolete crypto dependency in tests.
+
 Added PrintableString and UTC Time elements
 
 Changes to support RSA Private key : PEM file

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,4 @@ environment:
 dependencies:
   bignum: '>=0.0.5 <1.0.0'
 dev_dependencies:
-  crypto: any
   test: any

--- a/test/asn1element_test.dart
+++ b/test/asn1element_test.dart
@@ -5,8 +5,8 @@ library asn1test;
 import 'package:test/test.dart';
 import 'package:asn1lib/asn1lib.dart';
 import "package:bignum/bignum.dart";
-import "package:crypto/crypto.dart";
 
+import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:math';
 import 'dart:io';
@@ -182,7 +182,7 @@ main() {
     String pem = rsa_private_key_file.readAsStringSync();
     List lines  = pem.split("\n").map((line)=>line.trim()).skipWhile((String line)=>!line.startsWith("---")).toList();
     String key = lines.sublist(1, lines.length-2).join("");
-    var key_bytes = new Uint8List.fromList(CryptoUtils.base64StringToBytes(key));
+    var key_bytes = new Uint8List.fromList(BASE64.decode(key));
 
     var p = new ASN1Parser(key_bytes);
     expect(p.hasNext() , equals(true));
@@ -221,7 +221,7 @@ main() {
       String pem = rsa_private_key_file.readAsStringSync();
       List lines  = pem.split("\n").map((line)=>line.trim()).skipWhile((String line)=>!line.startsWith("---")).toList();
       String key = lines.sublist(1, lines.length-2).join("");
-      var key_bytes = new Uint8List.fromList(CryptoUtils.base64StringToBytes(key));
+      var key_bytes = new Uint8List.fromList(BASE64.decode(key));
 
       var p = new ASN1Parser(key_bytes);
       expect(p.hasNext() , equals(true));
@@ -265,7 +265,8 @@ main() {
         "QlNWVd4DOoJ/cPXsXwry8pWjNCo5JD8Q+RQ5yZEy7YPoifwemLhTdsBz3hlZr28oCGJ3kbnp\n"
         "W0xGvQb3VHSTVVbeei0CfXoW6iz1\n";
 
-    var cert_bytes = new Uint8List.fromList(CryptoUtils.base64StringToBytes(pem));
+    pem =  pem = pem.replaceAll("\n", "");
+    var cert_bytes = new Uint8List.fromList(BASE64.decode(pem));
 
     var p = new ASN1Parser(cert_bytes);
     expect(p.hasNext() , equals(true));


### PR DESCRIPTION
Crypto 1.0 removes the base64 functionality, which is also in dart:convert, so use that.