### PR TITLE
Expand functionality of OIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.5
+
+Merged #27
+
+Updates to ASN1ObjectIdentifier to:
+
+* allow creation from dotted number lists
+* allow creation from dotted number strings
+* allow names to be registered, for shorthands
+* allow bulk name registration
+* commonly used names (obviously, what this is could be expanded)
+
 ## 0.5.4
 
 Fixed #26

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -73,4 +73,53 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
         registerObjectIdentiferName(key, ASN1ObjectIdentifier.fromComponentString(value));
       });
     }
+
+  static registerFrequentNames() {
+    registerManyNames({
+      // https://tools.ietf.org/html/rfc2256
+      "cn": "2.5.4.3",
+      "sn": "2.5.4.4",
+      "c": "2.5.4.6",
+      "l": "2.5.4.7",
+      "st": "2.5.4.8",
+      "s": "2.5.4.8", // alias
+      "o": "2.5.4.10",
+      "ou": "2.5.4.11",
+      "title": "2.5.4.12",
+      "registeredAddress": "2.5.4.26",
+      "member": "2.5.4.31",
+      "owner": "2.5.4.32",
+      "roleOccupant": "2.5.4.33",
+      "seeAlso": "2.5.4.34",
+      "givenName": "2.5.4.42",
+      "initials": "2.5.4.43",
+      "generationQualifier": "2.5.4.44",
+      "dmdName": "2.5.4.54",
+      "alias": "2.5.6.1",
+      "country": "2.5.6.2",
+      "locality": "2.5.6.3",
+      "organization": "2.5.6.4",
+      "organizationalUnit": "2.5.6.5",
+      "person": "2.5.6.6",
+      "organizationalPerson": "2.5.6.7",
+      "organizationalRole": "2.5.6.8",
+      "groupOfNames": "2.5.6.9",
+      "residentialPerson": "2.5.6.10",
+      "applicationProcess": "2.5.6.11",
+      "applicationEntity": "2.5.6.12",
+      "dSA": "2.5.6.13",
+      "device": "2.5.6.14",
+      "strongAuthenticationUser": "2.5.6.15",
+      "certificationAuthority": "2.5.6.16",
+      "groupOfUniqueNames": "2.5.6.17",
+      "userSecurityInformation": "2.5.6.18",
+      "certificationAuthority-V2": "2.5.6.16.2",
+      "cRLDistributionPoint": "2.5.6.19",
+      "dmd": "2.5.6.20",
+
+      // X.509
+      "md5WithRSAEncryption": "1.2.840.113549.1.1.4",
+      "rsaEncryption": "1.2.840.113549.1.1.1",
+    });
+  }
 }

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -16,4 +16,38 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
       _setValueBytes(oi);
       return _encodedBytes;
     }
+
+  static ASN1ObjectIdentifier fromComponentString(String path) =>
+      fromComponents(path.split(".").map((v) => int.parse(v)).toList());  
+
+  static ASN1ObjectIdentifier fromComponents(List<int> components) {
+      assert(components.length >= 2);
+      assert(components[0] < 3);
+      assert(components[1] < 64);
+
+      List<int> oi = List<int>();
+      oi.add((components[0] << 4) | components[1]);
+
+      for (var ci = 2; ci < components.length; ci++) {
+        int position = oi.length;
+        int v = components[ci];
+        assert(v > 0);
+        
+        bool first = true;
+        do {
+            int remainder = v & 127;
+            v = v >> 7;
+
+            if (first) {
+                first = false;
+            } else {
+                remainder |= 0x80;
+            }
+
+            oi.insert(position, remainder);
+        } while (v > 0);
+      }
+
+      return ASN1ObjectIdentifier(oi);
+    }
 }

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -17,27 +17,26 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
       return _encodedBytes;
     }
 
-  static ASN1ObjectIdentifier fromComponentString(String path) =>
-      fromComponents(path.split(".").map((v) => int.parse(v)).toList());  
+  static ASN1ObjectIdentifier fromComponentString(String path,{tag:OBJECT_IDENTIFIER}) =>
+      fromComponents(path.split(".").map((v) => int.parse(v)).toList(), tag:tag);  
 
-  static ASN1ObjectIdentifier fromComponents(List<int> components) {
+  static ASN1ObjectIdentifier fromComponents(List<int> components,{tag:OBJECT_IDENTIFIER}) {
       assert(components.length >= 2);
       assert(components[0] < 3);
       assert(components[1] < 64);
 
       List<int> oi = List<int>();
-      oi.add((components[0] << 4) | components[1]);
+      oi.add(components[0] * 40 + components[1]);
 
       for (var ci = 2; ci < components.length; ci++) {
         int position = oi.length;
         int v = components[ci];
         assert(v > 0);
-        
+
         bool first = true;
         do {
             int remainder = v & 127;
             v = v >> 7;
-
             if (first) {
                 first = false;
             } else {
@@ -48,6 +47,24 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
         } while (v > 0);
       }
 
-      return ASN1ObjectIdentifier(oi);
+      return ASN1ObjectIdentifier(oi, tag:tag);
+    }
+
+  static Map<String,ASN1ObjectIdentifier> _names = Map<String,ASN1ObjectIdentifier>();
+    
+  static ASN1ObjectIdentifier fromName(String name,{tag:OBJECT_IDENTIFIER}) {
+      name = name.toLowerCase();
+      
+      for(MapEntry<String,ASN1ObjectIdentifier> entry in _names.entries) {
+        if (entry.key == name) {
+          return ASN1ObjectIdentifier(entry.value.oi, tag:entry.value.tag);
+        }
+      }
+
+      return null;
+    }
+
+  static registerObjectIdentiferName(String name, ASN1ObjectIdentifier oid) {
+      _names[name.toLowerCase()] = oid;
     }
 }

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -67,4 +67,10 @@ class ASN1ObjectIdentifier  extends ASN1Object  {
   static registerObjectIdentiferName(String name, ASN1ObjectIdentifier oid) {
       _names[name.toLowerCase()] = oid;
     }
+
+  static registerManyNames(Map<String,String> pairs) {
+      pairs.forEach((key, value) {
+        registerObjectIdentiferName(key, ASN1ObjectIdentifier.fromComponentString(value));
+      });
+    }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 0.5.4
+version: 0.5.5
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Steven Roose <stevenroose@gmail.com>

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -1,0 +1,98 @@
+library asn1test;
+
+import 'package:test/test.dart';
+import 'package:asn1lib/asn1lib.dart';
+
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:io';
+
+// many tests from - http://luca.ntop.org/Teaching/Appunti/asn1.html
+// print(a.oi.map((x) => "0x" + x.toRadixString(16).padLeft(2, "0")));
+
+main() {
+  test("fromComponents", () {
+    // ISO member bodies
+    {
+      ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponents([
+        1,
+        2,
+      ]);
+      expect(a.oi, equals([0x12]));
+    }
+    // US (ANSI)
+    {
+      ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponents([
+        1,
+        2,
+        840,
+      ]);
+      expect(a.oi, equals([0x12, 0x86, 0x48]));
+    }
+    // RSA Data Security, Inc.
+    {
+      ASN1ObjectIdentifier a =
+          ASN1ObjectIdentifier.fromComponents([1, 2, 840, 113549]);
+      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
+    }
+    // RSA Data Security, Inc. PKCS
+    {
+      ASN1ObjectIdentifier a =
+          ASN1ObjectIdentifier.fromComponents([1, 2, 840, 113549, 1]);
+      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
+    }
+    // directory services (X.500)
+    {
+      ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponents([
+        2,
+        5,
+      ]);
+      expect(a.oi, equals([0x25]));
+    }
+    // directory services-algorithms
+    {
+      ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponents([
+        2,
+        5,
+        8,
+      ]);
+      expect(a.oi, equals([0x25, 0x08]));
+    }
+  });
+  test("fromComponentString", () {
+    // ISO member bodies
+    {
+      ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponentString("1.2");
+      expect(a.oi, equals([0x12]));
+    }
+    // US (ANSI)
+    {
+      ASN1ObjectIdentifier a =
+          ASN1ObjectIdentifier.fromComponentString("1.2.840");
+      expect(a.oi, equals([0x12, 0x86, 0x48]));
+    }
+    // RSA Data Security, Inc.
+    {
+      ASN1ObjectIdentifier a =
+          ASN1ObjectIdentifier.fromComponentString("1.2.840.113549");
+      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
+    }
+    // RSA Data Security, Inc. PKCS
+    {
+      ASN1ObjectIdentifier a =
+          ASN1ObjectIdentifier.fromComponentString("1.2.840.113549.1");
+      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
+    }
+    // directory services (X.500)
+    {
+      ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponentString("2.5");
+      expect(a.oi, equals([0x25]));
+    }
+    // directory services-algorithms
+    {
+      ASN1ObjectIdentifier a =
+          ASN1ObjectIdentifier.fromComponentString("2.5.8");
+      expect(a.oi, equals([0x25, 0x08]));
+    }
+  });
+}

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -18,7 +18,7 @@ main() {
         1,
         2,
       ]);
-      expect(a.oi, equals([0x12]));
+      expect(a.oi, equals([0x2a]));
     }
     // US (ANSI)
     {
@@ -27,19 +27,19 @@ main() {
         2,
         840,
       ]);
-      expect(a.oi, equals([0x12, 0x86, 0x48]));
+      expect(a.oi, equals([0x2a, 0x86, 0x48]));
     }
     // RSA Data Security, Inc.
     {
       ASN1ObjectIdentifier a =
           ASN1ObjectIdentifier.fromComponents([1, 2, 840, 113549]);
-      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
+      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
     }
     // RSA Data Security, Inc. PKCS
     {
       ASN1ObjectIdentifier a =
           ASN1ObjectIdentifier.fromComponents([1, 2, 840, 113549, 1]);
-      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
+      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
     }
     // directory services (X.500)
     {
@@ -47,7 +47,7 @@ main() {
         2,
         5,
       ]);
-      expect(a.oi, equals([0x25]));
+      expect(a.oi, equals([0x55]));
     }
     // directory services-algorithms
     {
@@ -56,43 +56,63 @@ main() {
         5,
         8,
       ]);
-      expect(a.oi, equals([0x25, 0x08]));
+      expect(a.oi, equals([0x55, 0x08]));
     }
   });
   test("fromComponentString", () {
     // ISO member bodies
     {
       ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponentString("1.2");
-      expect(a.oi, equals([0x12]));
+      expect(a.oi, equals([0x2a]));
     }
     // US (ANSI)
     {
       ASN1ObjectIdentifier a =
           ASN1ObjectIdentifier.fromComponentString("1.2.840");
-      expect(a.oi, equals([0x12, 0x86, 0x48]));
+      expect(a.oi, equals([0x2a, 0x86, 0x48]));
     }
     // RSA Data Security, Inc.
     {
       ASN1ObjectIdentifier a =
           ASN1ObjectIdentifier.fromComponentString("1.2.840.113549");
-      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
+      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
     }
     // RSA Data Security, Inc. PKCS
     {
       ASN1ObjectIdentifier a =
           ASN1ObjectIdentifier.fromComponentString("1.2.840.113549.1");
-      expect(a.oi, equals([0x12, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
+      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
     }
     // directory services (X.500)
     {
       ASN1ObjectIdentifier a = ASN1ObjectIdentifier.fromComponentString("2.5");
-      expect(a.oi, equals([0x25]));
+      expect(a.oi, equals([0x55]));
     }
     // directory services-algorithms
     {
       ASN1ObjectIdentifier a =
           ASN1ObjectIdentifier.fromComponentString("2.5.8");
-      expect(a.oi, equals([0x25, 0x08]));
+      expect(a.oi, equals([0x55, 0x08]));
     }
   });
+
+  test("fromName", () {
+    // test that registration works
+    ASN1ObjectIdentifier ou = ASN1ObjectIdentifier.fromComponentString("2.5.4.11");
+    ASN1ObjectIdentifier.registerObjectIdentiferName("Ou", ou);
+
+    // test lookup (noting case indepence)
+    {
+      ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("ou");
+      expect(got.oi, equals(ou.oi));
+      expect(got.tag, equals(ou.tag));
+    }
+
+    // test name doesn't exist
+    {
+      ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("doesNotExist");
+      expect(got, equals(null));
+    }
+  });
+
 }

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -115,4 +115,27 @@ main() {
     }
   });
 
+  test("registerManyNames", () {
+    ASN1ObjectIdentifier.registerManyNames({
+      "title": "2.5.4.12",
+      "givenName": "2.5.4.42",
+    });
+
+    ASN1ObjectIdentifier title = ASN1ObjectIdentifier.fromComponentString("2.5.4.12");
+    ASN1ObjectIdentifier givenName = ASN1ObjectIdentifier.fromComponentString("2.5.4.42");
+
+    {
+      ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("TITLE");
+      expect(got.oi, equals(title.oi));
+      expect(got.tag, equals(title.tag));
+    }
+
+    {
+      ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("GIVENNAME");
+      expect(got.oi, equals(givenName.oi));
+      expect(got.tag, equals(givenName.tag));
+    }
+
+  });
+
 }

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -137,5 +137,16 @@ main() {
     }
 
   });
+  test("registerFrequentNames", () {
+    ASN1ObjectIdentifier.registerFrequentNames();
 
+    ASN1ObjectIdentifier registeredAddress = ASN1ObjectIdentifier.fromComponentString("2.5.4.26");
+
+    {
+      ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("registeredAddress");
+      expect(got.oi, equals(registeredAddress.oi));
+      expect(got.tag, equals(registeredAddress.tag));
+    }
+
+  });
 }


### PR DESCRIPTION
Hopefully not overstepping here:

- allow creation from dotted number lists
- allow creation from dotted number strings
- allow names to be registered, for shorthands
- allow bulk name registration
- commonly used names (obviously, what this is could be expanded)

Includes test cases