### PR TITLE
Improve fromBytes. Logic from Java Bouncy Castle.

### DIFF
--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -1,125 +1,189 @@
 part of asn1lib;
 
-
-class ASN1ObjectIdentifier  extends ASN1Object  {
+class ASN1ObjectIdentifier extends ASN1Object {
+  static final Map<String, String> DN = {
+    "cn": "2.5.4.3",
+    "sn": "2.5.4.4",
+    "c": "2.5.4.6",
+    "l": "2.5.4.7",
+    "st": "2.5.4.8",
+    "s": "2.5.4.8",
+    "o": "2.5.4.10",
+    "ou": "2.5.4.11",
+    "title": "2.5.4.12",
+    "registeredAddress": "2.5.4.26",
+    "member": "2.5.4.31",
+    "owner": "2.5.4.32",
+    "roleOccupant": "2.5.4.33",
+    "seeAlso": "2.5.4.34",
+    "givenName": "2.5.4.42",
+    "initials": "2.5.4.43",
+    "generationQualifier": "2.5.4.44",
+    "dmdName": "2.5.4.54",
+    "alias": "2.5.6.1",
+    "country": "2.5.6.2",
+    "locality": "2.5.6.3",
+    "organization": "2.5.6.4",
+    "organizationalUnit": "2.5.6.5",
+    "person": "2.5.6.6",
+    "organizationalPerson": "2.5.6.7",
+    "organizationalRole": "2.5.6.8",
+    "groupOfNames": "2.5.6.9",
+    "residentialPerson": "2.5.6.10",
+    "applicationProcess": "2.5.6.11",
+    "applicationEntity": "2.5.6.12",
+    "dSA": "2.5.6.13",
+    "device": "2.5.6.14",
+    "strongAuthenticationUser": "2.5.6.15",
+    "certificationAuthority": "2.5.6.16",
+    "groupOfUniqueNames": "2.5.6.17",
+    "userSecurityInformation": "2.5.6.18",
+    "certificationAuthority-V2": "2.5.6.16.2",
+    "cRLDistributionPoint": "2.5.6.19",
+    "dmd": "2.5.6.20",
+    "md5WithRSAEncryption": "1.2.840.113549.1.1.4",
+    "rsaEncryption": "1.2.840.113549.1.1.1",
+  };
 
   List<int> oi;
-  
-  ASN1ObjectIdentifier(this.oi,{tag:OBJECT_IDENTIFIER}):super(tag:tag);
 
-  ASN1ObjectIdentifier.fromBytes(Uint8List bytes) : super.fromBytes(bytes);
+  String identifier;
+
+  ASN1ObjectIdentifier(this.oi, {this.identifier, tag: OBJECT_IDENTIFIER})
+      : super(tag: tag);
+
+  ASN1ObjectIdentifier.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
+    // ignore the first 2 bytes because they are the tag and the length
+    Uint8List subBytes = bytes.sublist(2, bytes.length);
+    int value = 0;
+    bool first = true;
+    BigInt bigValue = null;
+    List<int> list = [];
+    StringBuffer objId = StringBuffer();
+    for (int i = 0; i != subBytes.length; i++) {
+      int b = subBytes[i] & 0xff;
+
+      if (value < 0x80000000000000) {
+        value = value * 128 + (b & 0x7f);
+        if ((b & 0x80) == 0) {
+          if (first) {
+            switch (value ~/ 40) {
+              case 0:
+                list.add(0);
+                objId.write('0');
+                break;
+              case 1:
+                list.add(1);
+                objId.write('1');
+                value -= 40;
+                break;
+              default:
+                list.add(2);
+                objId.write('2');
+                value -= 80;
+            }
+            first = false;
+          }
+          list.add(value);
+          objId.write('.');
+          objId.write(value);
+          value = 0;
+        }
+      } else {
+        if (bigValue == null) {
+          bigValue = BigInt.from(value);
+        }
+        bigValue = bigValue << (7);
+        bigValue = bigValue | BigInt.from(b & 0x7f);
+        if ((b & 0x80) == 0) {
+          objId.write('.');
+          objId.write(bigValue);
+          bigValue = null;
+          value = 0;
+        }
+      }
+    }
+    String objIdAsString = objId.toString();
+
+    for (String k in DN.keys) {
+      if (DN[k] == objIdAsString) {
+        this.oi = list;
+        this.identifier = objId.toString();
+      }
+    }
+  }
 
   @override
   Uint8List _encode() {
-      _valueByteLength  = oi.length;
-      super._encodeHeader();
-      _setValueBytes(oi);
-      return _encodedBytes;
-    }
+    _valueByteLength = oi.length;
+    super._encodeHeader();
+    _setValueBytes(oi);
+    return _encodedBytes;
+  }
 
-  static ASN1ObjectIdentifier fromComponentString(String path,{tag:OBJECT_IDENTIFIER}) =>
-      fromComponents(path.split(".").map((v) => int.parse(v)).toList(), tag:tag);  
+  static ASN1ObjectIdentifier fromComponentString(String path,
+          {tag: OBJECT_IDENTIFIER}) =>
+      fromComponents(path.split(".").map((v) => int.parse(v)).toList(),
+          tag: tag);
 
-  static ASN1ObjectIdentifier fromComponents(List<int> components,{tag:OBJECT_IDENTIFIER}) {
-      assert(components.length >= 2);
-      assert(components[0] < 3);
-      assert(components[1] < 64);
+  static ASN1ObjectIdentifier fromComponents(List<int> components,
+      {tag: OBJECT_IDENTIFIER}) {
+    assert(components.length >= 2);
+    assert(components[0] < 3);
+    assert(components[1] < 64);
 
-      List<int> oi = List<int>();
-      oi.add(components[0] * 40 + components[1]);
+    List<int> oi = List<int>();
+    oi.add(components[0] * 40 + components[1]);
 
-      for (var ci = 2; ci < components.length; ci++) {
-        int position = oi.length;
-        int v = components[ci];
-        assert(v > 0);
+    for (var ci = 2; ci < components.length; ci++) {
+      int position = oi.length;
+      int v = components[ci];
+      assert(v > 0);
 
-        bool first = true;
-        do {
-            int remainder = v & 127;
-            v = v >> 7;
-            if (first) {
-                first = false;
-            } else {
-                remainder |= 0x80;
-            }
-
-            oi.insert(position, remainder);
-        } while (v > 0);
-      }
-
-      return ASN1ObjectIdentifier(oi, tag:tag);
-    }
-
-  static Map<String,ASN1ObjectIdentifier> _names = Map<String,ASN1ObjectIdentifier>();
-    
-  static ASN1ObjectIdentifier fromName(String name,{tag:OBJECT_IDENTIFIER}) {
-      name = name.toLowerCase();
-      
-      for(MapEntry<String,ASN1ObjectIdentifier> entry in _names.entries) {
-        if (entry.key == name) {
-          return ASN1ObjectIdentifier(entry.value.oi, tag:entry.value.tag);
+      bool first = true;
+      do {
+        int remainder = v & 127;
+        v = v >> 7;
+        if (first) {
+          first = false;
+        } else {
+          remainder |= 0x80;
         }
-      }
 
-      return null;
+        oi.insert(position, remainder);
+      } while (v > 0);
     }
+
+    return ASN1ObjectIdentifier(oi, tag: tag);
+  }
+
+  static Map<String, ASN1ObjectIdentifier> _names =
+      Map<String, ASN1ObjectIdentifier>();
+
+  static ASN1ObjectIdentifier fromName(String name, {tag: OBJECT_IDENTIFIER}) {
+    name = name.toLowerCase();
+
+    for (MapEntry<String, ASN1ObjectIdentifier> entry in _names.entries) {
+      if (entry.key == name) {
+        return ASN1ObjectIdentifier(entry.value.oi, tag: entry.value.tag);
+      }
+    }
+
+    return null;
+  }
 
   static registerObjectIdentiferName(String name, ASN1ObjectIdentifier oid) {
-      _names[name.toLowerCase()] = oid;
-    }
+    _names[name.toLowerCase()] = oid;
+  }
 
-  static registerManyNames(Map<String,String> pairs) {
-      pairs.forEach((key, value) {
-        registerObjectIdentiferName(key, ASN1ObjectIdentifier.fromComponentString(value));
-      });
-    }
+  static registerManyNames(Map<String, String> pairs) {
+    pairs.forEach((key, value) {
+      registerObjectIdentiferName(
+          key, ASN1ObjectIdentifier.fromComponentString(value));
+    });
+  }
 
   static registerFrequentNames() {
-    registerManyNames({
-      // https://tools.ietf.org/html/rfc2256
-      "cn": "2.5.4.3",
-      "sn": "2.5.4.4",
-      "c": "2.5.4.6",
-      "l": "2.5.4.7",
-      "st": "2.5.4.8",
-      "s": "2.5.4.8", // alias
-      "o": "2.5.4.10",
-      "ou": "2.5.4.11",
-      "title": "2.5.4.12",
-      "registeredAddress": "2.5.4.26",
-      "member": "2.5.4.31",
-      "owner": "2.5.4.32",
-      "roleOccupant": "2.5.4.33",
-      "seeAlso": "2.5.4.34",
-      "givenName": "2.5.4.42",
-      "initials": "2.5.4.43",
-      "generationQualifier": "2.5.4.44",
-      "dmdName": "2.5.4.54",
-      "alias": "2.5.6.1",
-      "country": "2.5.6.2",
-      "locality": "2.5.6.3",
-      "organization": "2.5.6.4",
-      "organizationalUnit": "2.5.6.5",
-      "person": "2.5.6.6",
-      "organizationalPerson": "2.5.6.7",
-      "organizationalRole": "2.5.6.8",
-      "groupOfNames": "2.5.6.9",
-      "residentialPerson": "2.5.6.10",
-      "applicationProcess": "2.5.6.11",
-      "applicationEntity": "2.5.6.12",
-      "dSA": "2.5.6.13",
-      "device": "2.5.6.14",
-      "strongAuthenticationUser": "2.5.6.15",
-      "certificationAuthority": "2.5.6.16",
-      "groupOfUniqueNames": "2.5.6.17",
-      "userSecurityInformation": "2.5.6.18",
-      "certificationAuthority-V2": "2.5.6.16.2",
-      "cRLDistributionPoint": "2.5.6.19",
-      "dmd": "2.5.6.20",
-
-      // X.509
-      "md5WithRSAEncryption": "1.2.840.113549.1.1.4",
-      "rsaEncryption": "1.2.840.113549.1.1.1",
-    });
+    registerManyNames(DN);
   }
 }

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -3,9 +3,7 @@ library asn1test;
 import 'package:test/test.dart';
 import 'package:asn1lib/asn1lib.dart';
 
-import 'dart:convert';
 import 'dart:typed_data';
-import 'dart:io';
 
 // many tests from - http://luca.ntop.org/Teaching/Appunti/asn1.html
 // print(a.oi.map((x) => "0x" + x.toRadixString(16).padLeft(2, "0")));
@@ -98,7 +96,8 @@ main() {
 
   test("fromName", () {
     // test that registration works
-    ASN1ObjectIdentifier ou = ASN1ObjectIdentifier.fromComponentString("2.5.4.11");
+    ASN1ObjectIdentifier ou =
+        ASN1ObjectIdentifier.fromComponentString("2.5.4.11");
     ASN1ObjectIdentifier.registerObjectIdentiferName("Ou", ou);
 
     // test lookup (noting case indepence)
@@ -121,8 +120,10 @@ main() {
       "givenName": "2.5.4.42",
     });
 
-    ASN1ObjectIdentifier title = ASN1ObjectIdentifier.fromComponentString("2.5.4.12");
-    ASN1ObjectIdentifier givenName = ASN1ObjectIdentifier.fromComponentString("2.5.4.42");
+    ASN1ObjectIdentifier title =
+        ASN1ObjectIdentifier.fromComponentString("2.5.4.12");
+    ASN1ObjectIdentifier givenName =
+        ASN1ObjectIdentifier.fromComponentString("2.5.4.42");
 
     {
       ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("TITLE");
@@ -135,18 +136,29 @@ main() {
       expect(got.oi, equals(givenName.oi));
       expect(got.tag, equals(givenName.tag));
     }
-
   });
   test("registerFrequentNames", () {
     ASN1ObjectIdentifier.registerFrequentNames();
 
-    ASN1ObjectIdentifier registeredAddress = ASN1ObjectIdentifier.fromComponentString("2.5.4.26");
+    ASN1ObjectIdentifier registeredAddress =
+        ASN1ObjectIdentifier.fromComponentString("2.5.4.26");
 
     {
-      ASN1ObjectIdentifier got = ASN1ObjectIdentifier.fromName("registeredAddress");
+      ASN1ObjectIdentifier got =
+          ASN1ObjectIdentifier.fromName("registeredAddress");
       expect(got.oi, equals(registeredAddress.oi));
       expect(got.tag, equals(registeredAddress.tag));
     }
+  });
 
+  test("fromBytes", () {
+    Uint8List bytes = Uint8List.fromList([0x06, 0x03, 0x55, 0x04, 0x03]);
+    ASN1ObjectIdentifier objId = ASN1ObjectIdentifier.fromBytes(bytes);
+    expect(objId.identifier, "2.5.4.3");
+    expect(objId.oi.length, 4);
+    expect(objId.oi.elementAt(0), 2);
+    expect(objId.oi.elementAt(1), 5);
+    expect(objId.oi.elementAt(2), 4);
+    expect(objId.oi.elementAt(3), 3);
   });
 }


### PR DESCRIPTION
The identifier is not initialized if the ObjectIdentifier is created by the fromBytes method. I updated the method and used the logic from the equivalent class in Java BouncyCastle at https://github.com/bcgit/bc-java/blob/738dfc0132323d66ad27e7ec366666ed3e0638ab/core/src/main/java/org/bouncycastle/asn1/ASN1ObjectIdentifier.java

I also added a new unit test.

Regards