### PR TITLE
Update length computing of ANS1Parser

### DIFF
--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -43,6 +43,7 @@ class ASN1ObjectIdentifier extends ASN1Object {
     "dmd": "2.5.6.20",
     "md5WithRSAEncryption": "1.2.840.113549.1.1.4",
     "rsaEncryption": "1.2.840.113549.1.1.1",
+    "sha256WithRSAEncryption": "1.2.840.113549.1.1.11"
   };
 
   List<int> oi;


### PR DESCRIPTION
Hello, I found a bug in the parsing of ANS1. I tried to parse the data within a certificate and found out that the length of the values of the ANS1Objects was not calculated right.

Therefore i made some changes, to calculate the length by using the octet after the identifier. This octet describes the length of the following value.

I improved the unit test "Test decode certificate", by parsing more data out of the certificate used in this test.

I also check the length of each ANS1Object by debugging the test and comparing it with the output on https://lapo.it/asn1js/.

Also added a new distingished name value and reformat the code.

Regards