### PR TITLE
Improve length computing by using ASN1Length class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.12
+
+- Merged #36. Improved length computing in the ASN1Parser. 
+
 ## 0.5.11
 
 - Merged #34. Added example

--- a/lib/asn1parser.dart
+++ b/lib/asn1parser.dart
@@ -30,9 +30,11 @@ class ASN1Parser {
     bool isApplication = (0x40 & tag) != 0;
 
     //int l = _bytes.length - _position;
+
     int l = 0;
-    if (_bytes.length >= _position + 1) {
-      l = _bytes[_position + 1] + 2;
+    ASN1Length length = ASN1Length.decodeLength(_bytes);
+    if (_position < length.length + length.valueStartPosition) {
+      l = length.length + length.valueStartPosition;
     } else {
       l = _bytes.length - _position;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: asn1lib
-version: 0.5.11
+version: 0.5.12
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Steven Roose <stevenroose@gmail.com>
 - Jonas Kello <jonas.kello@gmail.com>
 - David Janes <davidjanes@davidjanes.com>
-- Ephenodrom <daniel@ephenodrom.de>
+- Daniel Linsenmeier <daniel@ephenodrom.de>
 description: An ASN1 parser library for Dart. Encodes / decodes from ASN1 Objects to BER bytes
 homepage: https://github.com/wstrange/asn1lib
 environment:

--- a/test/asn1_integer_test.dart
+++ b/test/asn1_integer_test.dart
@@ -162,6 +162,7 @@ final List<int> longTestValues = [
   8
 ];
 
+/*
 String _printBytes(List<int> b) {
   var s = "";
   b.forEach((e) {
@@ -169,6 +170,7 @@ String _printBytes(List<int> b) {
   });
   return s;
 }
+*/
 
 // iterate over the list - which is a pair of (value,expected number of encoded bytes)
 void testList(List<int> l) {
@@ -184,8 +186,8 @@ void testList(List<int> l) {
 
 void testPair(int x, int expectedLength) {
   var int1 = ASN1Integer.fromInt(x);
-  print(
-      "Value 0x${x.toRadixString(16)},$expectedLength. Encoded Bytes =  ${_printBytes(int1.encodedBytes.sublist(2))}");
+  //print(
+  //    "Value 0x${x.toRadixString(16)},$expectedLength. Encoded Bytes =  ${_printBytes(int1.encodedBytes.sublist(2))}");
 
   var contentLength = int1.contentBytes().length;
   expect(contentLength, expectedLength,

--- a/test/asn1element_test.dart
+++ b/test/asn1element_test.dart
@@ -73,6 +73,18 @@ main() {
     }
   });
 
+  test('Length decoding', () {
+    var b = Uint8List.fromList([0x30, 0x82, 0x01, 0x26]); // missing 0x00
+
+    try {
+      // ignore: unused_local_variable
+      var x = ASN1Length.decodeLength(b);
+      expect(294, x.length);
+    } catch (e) {
+      fail("No error expected");
+    }
+  });
+
   test('Octet String encoding', () {
     var s = "Hello";
     var os = ASN1OctetString(s);
@@ -103,6 +115,20 @@ main() {
 
     expect(t1.stringValue, equals("Hello"));
     expect(t2.stringValue, equals("World"));
+  });
+
+  test('Sequence Test2', () {
+    String hex =
+        "30 82 01 26 30 82 01 22 30 0D 06 09 2A 86 48 86 F7 0D 01 01 01 05 00 03 82 01 0F 00 30 82 01 0A 02 82 01 01 00 90 1A C7 35 D4 3F D7 82 7A F4 E5 E6 89 63 21 2B 7A 19 8B 0C B5 FF F5 7B 14 6E 05 53 A8 45 37 3D AB 5F 75 35 C9 A0 AC C7 65 0D 49 FF 2F 58 E5 C0 F4 BE CD 06 84 7D E9 97 49 30 37 C4 72 D6 CC E9 63 68 A5 DC 67 38 1F B7 4B 9F 1D CD 90 77 84 76 DF 73 96 93 44 84 A5 47 79 B9 78 A5 1B 7B 3F 82 95 F1 CA 45 9F C6 96 32 1F 6F 23 13 C2 33 BC 62 F8 17 50 7C 1A 4A 0C C1 DC D8 14 E6 D5 F6 63 03 A6 77 4F CD 2B 70 3E 51 6B 6C 9D 1E 51 22 14 F1 19 B1 FD 4C 68 64 34 2C DA 54 86 F9 8F BE 3F 45 AB 6B 3F 82 95 11 0C E0 92 8D 17 CD F5 32 5E F3 29 C5 6E F1 B6 7C 6B 8F 76 B2 44 F9 ED 5C D6 D0 19 FB 93 A3 47 20 59 50 20 55 4B 06 6E AB 29 08 63 5F 60 E4 BA 0F 81 B4 2B DF 26 F8 F0 D4 5D D8 27 2B F2 02 10 71 E7 84 B3 B7 6A 5F 92 5A F3 A0 CB 3A D3 01 24 25 1E 66 7B 6F 22 FA DE 8C F0 5D 02 03 01 00 01";
+    List<String> splitted = hex.split(" ");
+    List<int> ints = [];
+    splitted.forEach((String s) {
+      ints.add(int.parse(s, radix: 16));
+    });
+    var s = ASN1Sequence.fromBytes(Uint8List.fromList(ints));
+    s.encodedBytes.length;
+    int length = s.elements.elementAt(0).encodedBytes.length;
+    expect(length, 294);
   });
 
   test('Create sequence test2', () {


### PR DESCRIPTION
Hello,

while parsing a certificate and trying to create a sha1 thumbprint of the public key, i found out that the length computing was wrong. The length computing did not consider valuebytes with big length. Therefore i changed the computing by using the corresponding static method from the ASN1Length class.

I checked all unit tests and added 2 new tests.

Regards