### PR TITLE
improve length computing for ASN1Sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.5.13
+
+- Merged #37. Improved length computing in the ASN1Parser.
+- Added new unit tests.
+
 ## 0.5.12
 
-- Merged #36. Improved length computing in the ASN1Parser. 
+- Merged #36. Improved length computing in the ASN1Parser.
 
 ## 0.5.11
 
@@ -46,31 +51,29 @@ Merged #27
 
 Updates to ASN1ObjectIdentifier to:
 
-* allow creation from dotted number lists
-* allow creation from dotted number strings
-* allow names to be registered, for shorthands
-* allow bulk name registration
-* commonly used names (obviously, what this is could be expanded)
+- allow creation from dotted number lists
+- allow creation from dotted number strings
+- allow names to be registered, for shorthands
+- allow bulk name registration
+- commonly used names (obviously, what this is could be expanded)
 
 ## 0.5.4
 
 Fixed #26
 
-## 0.5.1 
+## 0.5.1
 
 Add AS1Integer.fromInt factory method
- 
-## 0.5.0 
 
-* Convert use of BigInteger to dart SDK BigInt
+## 0.5.0
 
-## 0.4.3 
+- Convert use of BigInteger to dart SDK BigInt
 
-* Updates for dart 2
+## 0.4.3
 
+- Updates for dart 2
 
 ## 0.4.2
 
-* Added `contentBytes()` getter
-* Removed Int64List dependency and use bignum's BigInteger instead
- 
+- Added `contentBytes()` getter
+- Removed Int64List dependency and use bignum's BigInteger instead

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ASN.1 Parser for Dart.
+# ASN.1 Parser for Dart
 
 Encodes & decodes ASN1 using BER encoding.
 

--- a/lib/asn1constants.dart
+++ b/lib/asn1constants.dart
@@ -1,8 +1,6 @@
-
 part of asn1lib;
 
 // tag bytes for various ASN1 BER objects
-
 
 const int BOOLEAN_TYPE = 0x01;
 const int INTEGER_TYPE = 0x02;

--- a/lib/asn1lib.dart
+++ b/lib/asn1lib.dart
@@ -3,7 +3,6 @@ library asn1lib;
 import 'dart:typed_data';
 import 'dart:convert';
 
-
 part 'asn1integer.dart';
 part 'asn1enumerated.dart';
 

--- a/lib/asn1parser.dart
+++ b/lib/asn1parser.dart
@@ -14,6 +14,7 @@ class ASN1Parser {
   int _position = 0;
 
   bool hasNext() {
+    //return _position < ASN1Length.decodeLength(_bytes).length;
     return _position < _bytes.length;
   }
 
@@ -23,7 +24,7 @@ class ASN1Parser {
   ASN1Object nextObject() {
     int tag = _bytes[_position]; // get curren tag in stream
 
-    //print("parser tag = ${hex(tag)} bytes=${hex(_bytes)}");
+    // print("parser tag = ${tag} bytes=${_bytes}");
     // ASN1 Primitives have high bits 8/7 set to 0
 
     bool isPrimitive = (0xC0 & tag) == 0;
@@ -32,7 +33,7 @@ class ASN1Parser {
     //int l = _bytes.length - _position;
 
     int l = 0;
-    ASN1Length length = ASN1Length.decodeLength(_bytes);
+    ASN1Length length = ASN1Length.decodeLength(_bytes.sublist(_position));
     if (_position < length.length + length.valueStartPosition) {
       l = length.length + length.valueStartPosition;
     } else {
@@ -40,8 +41,8 @@ class ASN1Parser {
     }
 
     // create a view into the larger stream that includes the remaining un-parsed bytes
-    var subBytes =
-        Uint8List.view(_bytes.buffer, _position + _bytes.offsetInBytes, l);
+    int offset = _position + _bytes.offsetInBytes;
+    var subBytes = Uint8List.view(_bytes.buffer, offset, l);
     //print("parser _bytes=${_bytes} position=${_position} len=$l  bytes=${hex(subBytes)}");
 
     ASN1Object obj;

--- a/lib/asn1sequence.dart
+++ b/lib/asn1sequence.dart
@@ -10,14 +10,13 @@ class ASN1Sequence extends ASN1Object {
   List<ASN1Object> elements = List();
 
   ///
-  /// Create a sequence fromt the byte array [b].
+  /// Create a sequence fromt the byte array [bytes].
   ///
   /// Note that bytes array b could be longer than the actual encoded sequence - in which case
-  /// we ignore any remaining bytes
+  /// we ignore any remaining bytes.
   ///
   ASN1Sequence.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
-    // TODO Check if tag is a valid sequence type???
-    if ((tag & 0x30) == 0) {
+    if ((tag & SEQUENCE_TYPE) == 0) {
       throw ASN1Exception("The tag ${tag} does not look like a sequence type");
     }
     //print("ASN1Sequence valbytes=${hex(valueBytes())}");

--- a/lib/asn1set.dart
+++ b/lib/asn1set.dart
@@ -3,8 +3,6 @@ part of asn1lib;
 ///
 /// An ASN1Set.
 ///
-/// TODO This code can be shared with ASN1Sequence
-///
 class ASN1Set extends ASN1Object {
   Set<ASN1Object> elements = Set<ASN1Object>();
 
@@ -14,8 +12,7 @@ class ASN1Set extends ASN1Object {
   /// Note that bytes could be longer than the actual sequence - in which case we would ignore any remaining bytes
   ///
   ASN1Set.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
-    // TODO Check if tag is a valid sequence type???
-    if ((tag & 0x30) == 0) {
+    if ((tag & SET_TYPE) == 0) {
       throw ASN1Exception("The tag ${tag} does not look like a set type");
     }
     _decodeSet();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 0.5.12
+version: 0.5.13
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Steven Roose <stevenroose@gmail.com>

--- a/test/ans1_parser_test.dart
+++ b/test/ans1_parser_test.dart
@@ -1,0 +1,50 @@
+library asn1test;
+
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:asn1lib/asn1lib.dart';
+
+main() {
+  test('ASN1Parser Test1', () {
+    String hex =
+        "30 82 01 2B 30 82 01 27 A0 03 02 01 02 30 0D 06 09 2A 86 48 86 F7 0D 01 01 01 05 00 03 82 01 0F 00 30 82 01 0A 02 82 01 01 00 90 1A C7 35 D4 3F D7 82 7A F4 E5 E6 89 63 21 2B 7A 19 8B 0C B5 FF F5 7B 14 6E 05 53 A8 45 37 3D AB 5F 75 35 C9 A0 AC C7 65 0D 49 FF 2F 58 E5 C0 F4 BE CD 06 84 7D E9 97 49 30 37 C4 72 D6 CC E9 63 68 A5 DC 67 38 1F B7 4B 9F 1D CD 90 77 84 76 DF 73 96 93 44 84 A5 47 79 B9 78 A5 1B 7B 3F 82 95 F1 CA 45 9F C6 96 32 1F 6F 23 13 C2 33 BC 62 F8 17 50 7C 1A 4A 0C C1 DC D8 14 E6 D5 F6 63 03 A6 77 4F CD 2B 70 3E 51 6B 6C 9D 1E 51 22 14 F1 19 B1 FD 4C 68 64 34 2C DA 54 86 F9 8F BE 3F 45 AB 6B 3F 82 95 11 0C E0 92 8D 17 CD F5 32 5E F3 29 C5 6E F1 B6 7C 6B 8F 76 B2 44 F9 ED 5C D6 D0 19 FB 93 A3 47 20 59 50 20 55 4B 06 6E AB 29 08 63 5F 60 E4 BA 0F 81 B4 2B DF 26 F8 F0 D4 5D D8 27 2B F2 02 10 71 E7 84 B3 B7 6A 5F 92 5A F3 A0 CB 3A D3 01 24 25 1E 66 7B 6F 22 FA DE 8C F0 5D 02 03 01 00 01";
+    List<String> splitted = hex.split(" ");
+    List<int> ints = [];
+    splitted.forEach((String s) {
+      ints.add(int.parse(s, radix: 16));
+    });
+    ASN1Parser parser = ASN1Parser(Uint8List.fromList(ints));
+    ASN1Sequence sequence = parser.nextObject() as ASN1Sequence;
+    expect(sequence.encodedBytes.length, sequence.totalEncodedByteLength);
+
+    ASN1Sequence subsequence = sequence.elements.elementAt(0) as ASN1Sequence;
+    expect(subsequence.encodedBytes.length, subsequence.totalEncodedByteLength);
+
+    ASN1Object obj = subsequence.elements.elementAt(0);
+    ASN1Sequence subsubsequence =
+        subsequence.elements.elementAt(1) as ASN1Sequence;
+    ASN1BitString bitString =
+        subsequence.elements.elementAt(2) as ASN1BitString;
+
+    expect(obj.encodedBytes.length, obj.totalEncodedByteLength);
+    expect(subsubsequence.encodedBytes.length,
+        subsubsequence.totalEncodedByteLength);
+    expect(bitString.encodedBytes.length, bitString.totalEncodedByteLength);
+
+    ASN1ObjectIdentifier oid =
+        subsubsequence.elements.elementAt(0) as ASN1ObjectIdentifier;
+    ASN1Object nullObj = subsubsequence.elements.elementAt(1);
+    expect(oid.encodedBytes.length, oid.totalEncodedByteLength);
+    expect(nullObj.encodedBytes.length, nullObj.totalEncodedByteLength);
+
+    ASN1Parser subParser = ASN1Parser(bitString.contentBytes());
+    ASN1Sequence seq = subParser.nextObject() as ASN1Sequence;
+    expect(seq.encodedBytes.length, seq.totalEncodedByteLength);
+    ASN1Integer int1 = seq.elements.elementAt(0) as ASN1Integer;
+    ASN1Integer int2 = seq.elements.elementAt(1) as ASN1Integer;
+
+    expect(int1.encodedBytes.length, int1.totalEncodedByteLength);
+    expect(int2.encodedBytes.length, int2.totalEncodedByteLength);
+  });
+}


### PR DESCRIPTION
Hello,

I have some improvement for the length computing. There was a problem with the computing especially for ASN1Sequences.

Changes :
* Fix in the ASN1Parser
* Added a special unit test for this in the ans1_parser_test.dart file
* Fixed some linter problems in the README.md and CHANGELOG.md

I already updated the pubspec.yaml and the CHANGELOG.md.

Unit tests :
> pub run test
> 00:06 +48: All tests passed!                                    

Regards