### PR TITLE
Fix #41: Decoding OIDs from bytes does not complete if OID is not in DN map

### DIFF
--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -117,14 +117,9 @@ class ASN1ObjectIdentifier extends ASN1Object {
         }
       }
     }
-    var objIdAsString = objId.toString();
 
-    for (var k in DN.keys) {
-      if (DN[k] == objIdAsString) {
-        oi = list;
-        identifier = objId.toString();
-      }
-    }
+    oi = list;
+    identifier = objId.toString();
   }
 
   @override

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -151,4 +151,22 @@ void main() {
     expect(objId.oi.elementAt(2), 4);
     expect(objId.oi.elementAt(3), 3);
   });
+
+  /// Test fromBytes() with an oid that does not exist in the DN map
+  /// OID used for test is SNMP protocol "sysDesc"
+  test('fromBytes (Unrecognized)', () {
+    var bytes = Uint8List.fromList(
+        [0x06, 0x07, 0x2B, 0x06, 0x01, 0x02, 0x01, 0x01, 0x01]);
+    var objId = ASN1ObjectIdentifier.fromBytes(bytes);
+    expect(objId.identifier, '1.3.6.1.2.1.1.1');
+    expect(objId.oi.length, 8);
+    expect(objId.oi.elementAt(0), 1);
+    expect(objId.oi.elementAt(1), 3);
+    expect(objId.oi.elementAt(2), 6);
+    expect(objId.oi.elementAt(3), 1);
+    expect(objId.oi.elementAt(4), 2);
+    expect(objId.oi.elementAt(5), 1);
+    expect(objId.oi.elementAt(6), 1);
+    expect(objId.oi.elementAt(7), 1);
+  });
 }


### PR DESCRIPTION
Fixes #41 and adds new test