### PR TITLE
Fix/objectidentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.0
+
+- Improve object identifier tests
+- Fix ASN1ObjectIdentifier static methods fromBytes() and fromComponents()
+
 ## 0.6.5
 
 - Add new object identifiers

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -117,14 +117,9 @@ class ASN1ObjectIdentifier extends ASN1Object {
         }
       }
     }
-    var objIdAsString = objId.toString();
 
-    for (var k in DN.keys) {
-      if (DN[k] == objIdAsString) {
-        oi = list;
-        identifier = objId.toString();
-      }
-    }
+    oi = list;
+    identifier = objId.toString();
   }
 
   @override

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -129,29 +129,11 @@ class ASN1ObjectIdentifier extends ASN1Object {
 
   @override
   Uint8List _encode() {
-    _valueByteLength = oi.length;
-    super._encodeHeader();
-    _setValueBytes(oi);
-    return _encodedBytes;
-  }
+    var _valBytes = <int>[oi[0] * 40 + oi[1]];
 
-  static ASN1ObjectIdentifier fromComponentString(String path,
-          {tag = OBJECT_IDENTIFIER}) =>
-      fromComponents(path.split('.').map((v) => int.parse(v)).toList(),
-          tag: tag);
-
-  static ASN1ObjectIdentifier fromComponents(List<int> components,
-      {tag = OBJECT_IDENTIFIER}) {
-    assert(components.length >= 2);
-    assert(components[0] < 3);
-    assert(components[1] < 64);
-
-    var oi = <int>[];
-    oi.add(components[0] * 40 + components[1]);
-
-    for (var ci = 2; ci < components.length; ci++) {
-      var position = oi.length;
-      var v = components[ci];
+    for (var ci = 2; ci < oi.length; ci++) {
+      var position = _valBytes.length;
+      var v = oi[ci];
       assert(v > 0);
 
       var first = true;
@@ -164,11 +146,28 @@ class ASN1ObjectIdentifier extends ASN1Object {
           remainder |= 0x80;
         }
 
-        oi.insert(position, remainder);
+        _valBytes.insert(position, remainder);
       } while (v > 0);
     }
+    _valueByteLength = _valBytes.length;
+    super._encodeHeader();
+    _setValueBytes(_valBytes);
+    return _encodedBytes;
+  }
 
-    return ASN1ObjectIdentifier(oi, tag: tag);
+  static ASN1ObjectIdentifier fromComponentString(String path,
+          {tag = OBJECT_IDENTIFIER}) =>
+      fromComponents(path.split('.').map((v) => int.parse(v)).toList(),
+          tag: tag);
+
+  static ASN1ObjectIdentifier fromComponents(List<int> components,
+      {tag = OBJECT_IDENTIFIER}) {
+    assert(components.length >= 2);
+    assert(components[0] < 3);
+    assert(components[1] < 39);
+
+    return ASN1ObjectIdentifier(components,
+        identifier: components.join('.'), tag: tag);
   }
 
   static final _names = <String, ASN1ObjectIdentifier>{};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 0.6.5
+version: 0.7.0
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Steven Roose <stevenroose@gmail.com>

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -12,79 +12,163 @@ void main() {
   test('fromComponents', () {
     // ISO member bodies
     {
-      var a = ASN1ObjectIdentifier.fromComponents([
-        1,
-        2,
-      ]);
-      expect(a.oi, equals([0x2a]));
+      var a = ASN1ObjectIdentifier.fromComponents([1, 2]);
+      expect(a.encodedBytes, equals([0x06, 0x01, 0x2a]));
+      expect(a.identifier, '1.2');
+      expect(a.oi.length, 2);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
     }
     // US (ANSI)
     {
-      var a = ASN1ObjectIdentifier.fromComponents([
-        1,
-        2,
-        840,
-      ]);
-      expect(a.oi, equals([0x2a, 0x86, 0x48]));
+      var a = ASN1ObjectIdentifier.fromComponents([1, 2, 840]);
+      expect(a.encodedBytes, equals([0x06, 0x03, 0x2a, 0x86, 0x48]));
+      expect(a.identifier, '1.2.840');
+      expect(a.oi.length, 3);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
+      expect(a.oi.elementAt(2), 840);
     }
     // RSA Data Security, Inc.
     {
       var a = ASN1ObjectIdentifier.fromComponents([1, 2, 840, 113549]);
-      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
+      expect(a.encodedBytes,
+          equals([0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xF7, 0x0D]));
+      expect(a.identifier, '1.2.840.113549');
+      expect(a.oi.length, 4);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
+      expect(a.oi.elementAt(2), 840);
+      expect(a.oi.elementAt(3), 113549);
     }
     // RSA Data Security, Inc. PKCS
     {
       var a = ASN1ObjectIdentifier.fromComponents([1, 2, 840, 113549, 1]);
-      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
+      expect(a.encodedBytes,
+          equals([0x06, 0x07, 0x2a, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01]));
+      expect(a.identifier, '1.2.840.113549.1');
+      expect(a.oi.length, 5);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
+      expect(a.oi.elementAt(2), 840);
+      expect(a.oi.elementAt(3), 113549);
+      expect(a.oi.elementAt(4), 1);
     }
     // directory services (X.500)
     {
-      var a = ASN1ObjectIdentifier.fromComponents([
-        2,
-        5,
-      ]);
-      expect(a.oi, equals([0x55]));
+      var a = ASN1ObjectIdentifier.fromComponents([2, 5]);
+      expect(a.encodedBytes, equals([0x06, 0x01, 0x55]));
+      expect(a.identifier, '2.5');
+      expect(a.oi.length, 2);
+      expect(a.oi.elementAt(0), 2);
+      expect(a.oi.elementAt(1), 5);
     }
     // directory services-algorithms
     {
-      var a = ASN1ObjectIdentifier.fromComponents([
-        2,
-        5,
-        8,
-      ]);
-      expect(a.oi, equals([0x55, 0x08]));
+      var a = ASN1ObjectIdentifier.fromComponents([2, 5, 8]);
+      expect(a.encodedBytes, equals([0x06, 0x02, 0x55, 0x08]));
+      expect(a.identifier, '2.5.8');
+      expect(a.oi.length, 3);
+      expect(a.oi.elementAt(0), 2);
+      expect(a.oi.elementAt(1), 5);
+      expect(a.oi.elementAt(2), 8);
+    }
+
+    /// Test fromComponents() with an oid that does not exist in the DN map
+    /// OID used for test is SNMP protocol "sysDesc"
+    {
+      var objId = ASN1ObjectIdentifier.fromComponents([1, 3, 6, 1, 2, 1, 1, 1]);
+      expect(objId.identifier, '1.3.6.1.2.1.1.1');
+      expect(objId.oi.length, 8);
+      expect(objId.oi.elementAt(0), 1);
+      expect(objId.oi.elementAt(1), 3);
+      expect(objId.oi.elementAt(2), 6);
+      expect(objId.oi.elementAt(3), 1);
+      expect(objId.oi.elementAt(4), 2);
+      expect(objId.oi.elementAt(5), 1);
+      expect(objId.oi.elementAt(6), 1);
+      expect(objId.oi.elementAt(7), 1);
     }
   });
   test('fromComponentString', () {
     // ISO member bodies
     {
       var a = ASN1ObjectIdentifier.fromComponentString('1.2');
-      expect(a.oi, equals([0x2a]));
+      expect(a.encodedBytes, equals([0x06, 0x01, 0x2a]));
+      expect(a.identifier, '1.2');
+      expect(a.oi.length, 2);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
     }
     // US (ANSI)
     {
       var a = ASN1ObjectIdentifier.fromComponentString('1.2.840');
-      expect(a.oi, equals([0x2a, 0x86, 0x48]));
+      expect(a.encodedBytes, equals([0x06, 0x03, 0x2a, 0x86, 0x48]));
+      expect(a.identifier, '1.2.840');
+      expect(a.oi.length, 3);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
+      expect(a.oi.elementAt(2), 840);
     }
     // RSA Data Security, Inc.
     {
       var a = ASN1ObjectIdentifier.fromComponentString('1.2.840.113549');
-      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d]));
+      expect(a.encodedBytes,
+          equals([0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xF7, 0x0D]));
+      expect(a.identifier, '1.2.840.113549');
+      expect(a.oi.length, 4);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
+      expect(a.oi.elementAt(2), 840);
+      expect(a.oi.elementAt(3), 113549);
     }
     // RSA Data Security, Inc. PKCS
     {
       var a = ASN1ObjectIdentifier.fromComponentString('1.2.840.113549.1');
-      expect(a.oi, equals([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01]));
+      expect(a.encodedBytes,
+          equals([0x06, 0x07, 0x2a, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01]));
+      expect(a.identifier, '1.2.840.113549.1');
+      expect(a.oi.length, 5);
+      expect(a.oi.elementAt(0), 1);
+      expect(a.oi.elementAt(1), 2);
+      expect(a.oi.elementAt(2), 840);
+      expect(a.oi.elementAt(3), 113549);
+      expect(a.oi.elementAt(4), 1);
     }
     // directory services (X.500)
     {
       var a = ASN1ObjectIdentifier.fromComponentString('2.5');
-      expect(a.oi, equals([0x55]));
+      expect(a.encodedBytes, equals([0x06, 0x01, 0x55]));
+      expect(a.identifier, '2.5');
+      expect(a.oi.length, 2);
+      expect(a.oi.elementAt(0), 2);
+      expect(a.oi.elementAt(1), 5);
     }
     // directory services-algorithms
     {
       var a = ASN1ObjectIdentifier.fromComponentString('2.5.8');
-      expect(a.oi, equals([0x55, 0x08]));
+      expect(a.encodedBytes, equals([0x06, 0x02, 0x55, 0x08]));
+      expect(a.identifier, '2.5.8');
+      expect(a.oi.length, 3);
+      expect(a.oi.elementAt(0), 2);
+      expect(a.oi.elementAt(1), 5);
+      expect(a.oi.elementAt(2), 8);
+    }
+
+    /// Test fromComponentString() with an oid that does not exist in the DN map
+    /// OID used for test is SNMP protocol "sysDesc"
+    {
+      var objId = ASN1ObjectIdentifier.fromComponentString('1.3.6.1.2.1.1.1');
+      expect(objId.identifier, '1.3.6.1.2.1.1.1');
+      expect(objId.oi.length, 8);
+      expect(objId.oi.elementAt(0), 1);
+      expect(objId.oi.elementAt(1), 3);
+      expect(objId.oi.elementAt(2), 6);
+      expect(objId.oi.elementAt(3), 1);
+      expect(objId.oi.elementAt(4), 2);
+      expect(objId.oi.elementAt(5), 1);
+      expect(objId.oi.elementAt(6), 1);
+      expect(objId.oi.elementAt(7), 1);
     }
   });
 
@@ -142,13 +226,35 @@ void main() {
   });
 
   test('fromBytes', () {
-    var bytes = Uint8List.fromList([0x06, 0x03, 0x55, 0x04, 0x03]);
-    var objId = ASN1ObjectIdentifier.fromBytes(bytes);
-    expect(objId.identifier, '2.5.4.3');
-    expect(objId.oi.length, 4);
-    expect(objId.oi.elementAt(0), 2);
-    expect(objId.oi.elementAt(1), 5);
-    expect(objId.oi.elementAt(2), 4);
-    expect(objId.oi.elementAt(3), 3);
+    {
+      var bytes = Uint8List.fromList([0x06, 0x03, 0x55, 0x04, 0x03]);
+      var objId = ASN1ObjectIdentifier.fromBytes(bytes);
+      expect(objId.encodedBytes, equals(bytes));
+      expect(objId.identifier, '2.5.4.3');
+      expect(objId.oi.length, 4);
+      expect(objId.oi.elementAt(0), 2);
+      expect(objId.oi.elementAt(1), 5);
+      expect(objId.oi.elementAt(2), 4);
+      expect(objId.oi.elementAt(3), 3);
+    }
+
+    /// Test fromBytes() with an oid that does not exist in the DN map
+    /// OID used for test is SNMP protocol "sysDesc"
+    {
+      var bytes = Uint8List.fromList(
+          [0x06, 0x07, 0x2B, 0x06, 0x01, 0x02, 0x01, 0x01, 0x01]);
+      var objId = ASN1ObjectIdentifier.fromBytes(bytes);
+      expect(objId.encodedBytes, equals(bytes));
+      expect(objId.identifier, '1.3.6.1.2.1.1.1');
+      expect(objId.oi.length, 8);
+      expect(objId.oi.elementAt(0), 1);
+      expect(objId.oi.elementAt(1), 3);
+      expect(objId.oi.elementAt(2), 6);
+      expect(objId.oi.elementAt(3), 1);
+      expect(objId.oi.elementAt(4), 2);
+      expect(objId.oi.elementAt(5), 1);
+      expect(objId.oi.elementAt(6), 1);
+      expect(objId.oi.elementAt(7), 1);
+    }
   });
 }


### PR DESCRIPTION
Fix #41 and #43 

- Improved tests so that objects created using any of the methods ( fromBytes(), fromComponents(), fromComponentString() ) are tested to the same standards

- Modified static "factory" methods so that objects created using equivalent input will result in objects with identical behavior