### PR TITLE
Allow OID octets to be zero, fix typo, bump version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- Allow OID octets to be 0
+
 ## 0.8.0
 
 - Add ASN1IpAddress object based on ASN1OctetString

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.1
 
 - Allow OID octets to be 0
+- Fix ASN1Integer.toString() typo
 
 ## 0.8.0
 

--- a/lib/asn1integer.dart
+++ b/lib/asn1integer.dart
@@ -39,7 +39,7 @@ class ASN1Integer extends ASN1Object {
   static int decodeInt(Uint8List bytes) => decodeBigInt(bytes).toInt();
 
   @override
-  String toString() => 'ASNInteger($intValue)';
+  String toString() => 'ASN1Integer($intValue)';
 
   static final _b256 = BigInt.from(256);
   static final _minusOne = BigInt.from(-1);

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -129,7 +129,6 @@ class ASN1ObjectIdentifier extends ASN1Object {
     for (var ci = 2; ci < oi.length; ci++) {
       var position = _valBytes.length;
       var v = oi[ci];
-      assert(v > 0);
 
       var first = true;
       do {


### PR DESCRIPTION
Allowing zero octets improves SNMP compatibility (even if it is inadvisable per spec)
