### PR TITLE
Better toString() for ASN1ObjectIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.0.2
+
+- Better toString() for ASN1ObjectIdentifier
+  
 ### 1.0.1
 
 - Add ASN1NumericString support

--- a/lib/asn1objectidentifier.dart
+++ b/lib/asn1objectidentifier.dart
@@ -193,4 +193,7 @@ class ASN1ObjectIdentifier extends ASN1Object {
   static void registerFrequentNames() {
     registerManyNames(DN);
   }
+
+  @override
+  String toString() => 'ObjectIdentifier($identifier)';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 1.0.1
+version: 1.0.2
 description: An ASN1 parser library for Dart. Encodes / decodes from ASN1 Objects to BER bytes
 homepage: https://github.com/wstrange/asn1lib
 environment:

--- a/test/asn1objectidentifier_test.dart
+++ b/test/asn1objectidentifier_test.dart
@@ -256,4 +256,11 @@ void main() {
       expect(objId.oi.elementAt(7), 1);
     }
   });
+
+  test('toString', () {
+    var bytes = Uint8List.fromList(
+        [0x06, 0x07, 0x2B, 0x06, 0x01, 0x02, 0x01, 0x01, 0x01]);
+    var objId = ASN1ObjectIdentifier.fromBytes(bytes);
+    expect(objId.toString(), 'ObjectIdentifier(1.3.6.1.2.1.1.1)');
+  });
 }


### PR DESCRIPTION
Took me some time to figure out, why isn't ASN1ObjectIdentifier wasn't parsed correctly. As a matter of fact it did , but toString() output was highly misleading. So here is the small fix.