### PR TITLE
added relaxedParsing optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.1.0
+
+- Add optional flag whether to relax parsing, off by default, for backwards-compatibility
+
 ### 1.0.3
 
 - Add ASN1BMPString support

--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@ import 'package:asn1lib/asn1lib.dart';
 var p = ASN1Parser(bytes);
 var s2 = p.nextObject();
 // s2 is a sequence...
+
+
+// relaxed parsing, returning a generic ASN1Object from (yet) unsupported structures, instead of throwing
+var p2 = ASN1Parser(bytes, relaxedParsing: true);
+var s3 = p2.nextObject();
+// s3 is a sequence...
 ```

--- a/lib/asn1parser.dart
+++ b/lib/asn1parser.dart
@@ -9,7 +9,8 @@ class ASN1Parser {
   final bool _relaxedParsing;
 
   /// Create a new parser for the stream of [_bytes]
-  ASN1Parser(this._bytes, {bool relaxedParsing = false}) : _relaxedParsing = relaxedParsing;
+  ASN1Parser(this._bytes, {bool relaxedParsing = false})
+      : _relaxedParsing = relaxedParsing;
 
   /// current position in the byte array
   int _position = 0;
@@ -118,7 +119,8 @@ class ASN1Parser {
         if (_relaxedParsing) {
           return ASN1Object.fromBytes(b);
         }
-        throw ASN1Exception('Parser for tag $tag not implemented yet and relaxedParsing is off');
+        throw ASN1Exception(
+            'Parser for tag $tag not implemented yet and relaxedParsing is off');
     }
   }
 }

--- a/lib/asn1parser.dart
+++ b/lib/asn1parser.dart
@@ -6,9 +6,10 @@ part of asn1lib;
 class ASN1Parser {
   /// stream of bytes to parse. This might be a view into a longer stream
   final Uint8List _bytes;
+  final bool _relaxedParsing;
 
   /// Create a new parser for the stream of [_bytes]
-  ASN1Parser(this._bytes);
+  ASN1Parser(this._bytes, {bool relaxedParsing = false}) : _relaxedParsing = relaxedParsing;
 
   /// current position in the byte array
   int _position = 0;
@@ -114,7 +115,10 @@ class ASN1Parser {
         return ASN1TeletextString.fromBytes(b);
 
       default:
-        throw ASN1Exception('Parser for tag $tag not implemented yet');
+        if (_relaxedParsing) {
+          return ASN1Object.fromBytes(b);
+        }
+        throw ASN1Exception('Parser for tag $tag not implemented yet and relaxedParsing is off');
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 1.0.3
+version: 1.1.0
 description: An ASN1 parser library for Dart. Encodes / decodes from ASN1 Objects to BER bytes
 homepage: https://github.com/wstrange/asn1lib
 environment:


### PR DESCRIPTION
This flag controls whether the parser should throw on (yet) unsupported ASN1 structures (default), or attempt to parse them as generic ASN1Object instead (when enabled).

This is similar to pull request (and the comments on it) as https://github.com/wstrange/asn1lib/pull/56, since I honestly believe it would be useful to have this feature (I need it for once :)