### PR TITLE
Fix null exception when accessing valueBytes before encodedBytes

### DIFF
--- a/lib/asn1object.dart
+++ b/lib/asn1object.dart
@@ -140,8 +140,8 @@ class ASN1Object {
   /// This returns a view into the byte buffer
   ///
   Uint8List valueBytes() {
-    return Uint8List.view(_encodedBytes!.buffer,
-        _valueStartPosition + _encodedBytes!.offsetInBytes, _valueByteLength);
+    return Uint8List.view(encodedBytes.buffer,
+        _valueStartPosition + encodedBytes.offsetInBytes, _valueByteLength);
   }
 
   ///

--- a/test/der_encoding_test.dart
+++ b/test/der_encoding_test.dart
@@ -19,6 +19,12 @@ void main() {
       expect(n.encodedBytes, equals([0x05, 0x00]));
     });
 
+    test('valueBytes before encoding', () {
+      // null object
+      var n = ASN1OctetString('0123');
+      expect(n.valueBytes, returnsNormally);
+    });
+
     test('octet-string', () {
       // the octetstring 01 23 45 67 89 ab cd ef
       // should become 04 08 01 23 45 67 89 ab cd ef


### PR DESCRIPTION
Noticed this when doing some weird stuff in a project. If you had not called encodedBytes first, then some object types would throw. You can work around it, but the fix for it is pretty simple :)