### PR TITLE
fix: encoding DateTime with single digit month/day should not fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.6.3
+
+- The ASN1GeneralizedTime should not fail on decoding DateTime with single digit month, day, hour, minute or second.
+
 ### 1.6.2
 
 - The ASN1Object.hashCode method now uses the encodedBytes to calculate the hash code. This ensures that two objects that are equal (have the same encoded bytes) have the same hash code.

--- a/lib/src/asn1generalizedtime.dart
+++ b/lib/src/asn1generalizedtime.dart
@@ -43,12 +43,12 @@ class ASN1GeneralizedTime extends ASN1Object {
   @override
   Uint8List _encode() {
     var utc = dateTimeValue.toUtc();
-    var year = utc.year.toString();
-    var month = utc.month.toString();
-    var day = utc.day.toString();
-    var hour = utc.hour.toString();
-    var minute = utc.minute.toString();
-    var second = utc.second.toString();
+    var year = utc.year.toString().padLeft(4, '0');
+    var month = utc.month.toString().padLeft(2, '0');
+    var day = utc.day.toString().padLeft(2, '0');
+    var hour = utc.hour.toString().padLeft(2, '0');
+    var minute = utc.minute.toString().padLeft(2, '0');
+    var second = utc.second.toString().padLeft(2, '0');
     // Encode string to YYMMDDhhmm[ss]Z
     var utcString = '$year$month$day$hour$minute${second}Z';
     var valBytes = <int>[];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 1.6.2
+version: 1.6.3
 description: An ASN1 parser library for Dart. Encodes / decodes from ASN1 Objects to BER bytes
 homepage: https://github.com/wstrange/asn1lib
 environment:

--- a/test/asn1_generalized_time_test.dart
+++ b/test/asn1_generalized_time_test.dart
@@ -13,4 +13,13 @@ void main() {
     expect(encoded.length, bytes.length);
     expect(encoded, bytes);
   });
+
+  test('encode single digit month-day-hour-minute-second', () {
+    final dateTime = DateTime.utc(2025, 4, 1, 5, 2, 3);
+    final time = ASN1GeneralizedTime(dateTime);
+    final encodedTime = time.encodedBytes;
+
+    final decodedTime = ASN1GeneralizedTime.fromBytes(encodedTime);
+    expect(decodedTime.dateTimeValue, equals(dateTime));
+  });
 }


### PR DESCRIPTION
`ASN1GeneralizedTime` fails to decode from bytes when a `DateTime` with a single digit month, day, hour, minute or second has been encoded. The decoder expects a fixed length string therefore we need to left-pad encoded values with `0` to get fixed length string.

Unfortunately this is a breaking change since the encoding format changed. However it was wrongly encoded from the beginning (encoded in a way that makes it impossible to decode) so it's possible to assume it's not a critical change.