### PR TITLE
fix(ASN1OctetString): print non utf-8 octet strings as integer arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.6.4
+
+- ASN1OctetString.toString() now returns bytes as a list instead of throwing an exception when the contents can not be decoded as a UTF-8 string.
+
 ### 1.6.3
 
 - The ASN1GeneralizedTime should not fail on decoding DateTime with single digit month, day, hour, minute or second.

--- a/lib/src/asn1octetstring.dart
+++ b/lib/src/asn1octetstring.dart
@@ -33,7 +33,9 @@ class ASN1OctetString extends ASN1Object {
     } else if (octets is List<int>) {
       this.octets = Uint8List.fromList(octets);
     } else {
-      throw ArgumentError('Parameters octets should be either of type String or List<int>.');
+      throw ArgumentError(
+        'Parameters octets should be either of type String or List<int>.',
+      );
     }
   }
 
@@ -68,7 +70,14 @@ class ASN1OctetString extends ASN1Object {
   }
 
   @override
-  // Prints the string value of the octet string assuming utf-8 encoding
-  // This may not be what you want.
-  String toString() => utf8StringValue;
+  // Prints the string value of the octet string assuming utf-8 encoding.
+  // This may not be what you want. If the object contents can't be decoded
+  // as utf-8 string it is printed as an array of integer byte values.
+  String toString() {
+    try {
+      return utf8StringValue;
+    } catch (e) {
+      return octets.toString();
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: asn1lib
-version: 1.6.3
+version: 1.6.4
 description: An ASN1 parser library for Dart. Encodes / decodes from ASN1 Objects to BER bytes
 homepage: https://github.com/wstrange/asn1lib
 environment:

--- a/test/asn1element_test.dart
+++ b/test/asn1element_test.dart
@@ -87,6 +87,7 @@ void main() {
     var os = ASN1OctetString(s);
     var os2 = ASN1OctetString.fromBytes(os.encodedBytes);
     expect(os2.utf8StringValue, equals(s));
+    expect(os2.toString(), equals(s));
   });
 
   test('Octet get octets', () {
@@ -97,6 +98,9 @@ void main() {
     expect(os2.octets, equals(octets));
     expect(os2.encodedBytes, equals(os1.encodedBytes));
     expect(os2, equals(os1));
+
+    // Octet string containing something else than UTF-8 should be printed as integer array
+    expect(os2.toString(), equals(octets.toString()));
   });
 
   test('Sequence Test1', () {


### PR DESCRIPTION
Using Octet String as a container for utf-8 string is common but not always a case. Common case is GUID containing 16 raw bytes returned by ActiveDirectory and similar LDAP servers.

It would have been nice to print out that OctetStrings as an integer array when .toString() is called instead of throwing the exception so this patch does just that.